### PR TITLE
Julia's debug build and debug CI test failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ check-whitespace:
 ifneq ($(NO_GIT), 1)
 	@# Append the directory containing the julia we just built to the end of `PATH`,
 	@# to give us the best chance of being able to run this check.
-	@PATH="$(PATH):$(dir $(JULIA_EXECUTABLE))" julia $(call cygpath_w,$(JULIAHOME)/contrib/check-whitespace.jl)
+	@PATH="$(PATH):$(dir $(JULIA_EXECUTABLE))" $(JULIA_EXECUTABLE) $(call cygpath_w,$(JULIAHOME)/contrib/check-whitespace.jl)
 else
 	$(warn "Skipping whitespace check because git is unavailable")
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -176,7 +176,7 @@ DOBJS := $(SRCS:%=$(BUILDDIR)/%.dbg.obj)
 ifeq ($(WITH_MMTK), 1)
 MMTK_SRCS := mmtk_julia
 MMTK_OBJS := $(MMTK_SRCS:%=$(MMTK_JULIA_INC)/%.o) $(MMTK_LIB_DST)
-MMTK_DOBJS := $(MMTK_SRCS:%=$(MMTK_JULIA_INC)/%.dbg.obj)
+MMTK_DOBJS := $(MMTK_SRCS:%=$(MMTK_JULIA_INC)/%.dbg.obj) $(MMTK_LIB_DST)
 else
 MMTK_OBJS :=
 MMTK_DOBJS :=


### PR DESCRIPTION
Fixed issue that prevented building Julia or running tests with Julia's debug build. The MMTk library wasn't being copied and the tests used `julia` instead of `julia-debug` before running tests.