### PR TITLE
Set stock GC threads to 0

### DIFF
--- a/src/mmtk-gc.c
+++ b/src/mmtk-gc.c
@@ -350,8 +350,8 @@ void jl_gc_init(void)
         max_heap_size = uv_get_free_memory() * 70 / 100;
     }
 
-    // If the two values are the same, we can use either. Otherwise, we need to be careful.
-    assert(jl_n_gcthreads == jl_options.ngcthreads);
+    // Assert that the number of stock GC threads is 0; MMTK uses the number of threads in jl_options.ngcthreads
+    assert(jl_n_gcthreads == 0);
 
     // Check that the julia_copy_stack rust feature has been defined when the COPY_STACK has been defined
     int copy_stacks;

--- a/src/threading.c
+++ b/src/threading.c
@@ -667,6 +667,12 @@ void jl_init_threading(void)
         }
     }
 
+#ifdef MMTK_GC
+    // MMTk gets the number of GC threads from jl_options.ngcthreads, and spawn its GC threads.
+    // So we just set ngcthreads to 0 here to avoid spawning any GC threads in Julia.
+    ngcthreads = 0;
+#endif
+
     jl_all_tls_states_size = nthreads + nthreadsi + ngcthreads;
     jl_n_threads_per_pool = (int*)malloc_s(2 * sizeof(int));
     jl_n_threads_per_pool[0] = nthreadsi;
@@ -684,11 +690,6 @@ void jl_start_threads(void)
 {
     int nthreads = jl_atomic_load_relaxed(&jl_n_threads);
     int ngcthreads = jl_n_gcthreads;
-#ifdef MMTK_GC
-    // MMTk gets the number of GC threads from jl_options.ngcthreads, and spawn its GC threads.
-    // So we just set ngcthreads to 0 here to avoid spawning any GC threads in Julia.
-    ngcthreads = 0;
-#endif
     int cpumasksize = uv_cpumask_size();
     char *cp;
     int i, exclusive;


### PR DESCRIPTION
Fixing assertion that compares `jl_n_gcthreads == jl_options.ngcthreads`. We set `jl_n_gcthreads = 0`, and use `jl_options.ngcthreads` to set the number of MMTk workers. 