### PR TITLE
Adding support for allocating in a non-moving space

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -63,7 +63,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
 {
     jl_task_t *ct = jl_current_task;
     jl_typename_t *tn =
-        (jl_typename_t*)jl_gc_alloc(ct->ptls, sizeof(jl_typename_t),
+        (jl_typename_t*)jl_gc_alloc_non_moving(ct->ptls, sizeof(jl_typename_t),
                                     jl_typename_type);
     tn->name = name;
     tn->module = module;
@@ -95,7 +95,7 @@ jl_datatype_t *jl_new_abstracttype(jl_value_t *name, jl_module_t *module, jl_dat
 jl_datatype_t *jl_new_uninitialized_datatype(void)
 {
     jl_task_t *ct = jl_current_task;
-    jl_datatype_t *t = (jl_datatype_t*)jl_gc_alloc(ct->ptls, sizeof(jl_datatype_t), jl_datatype_type);
+    jl_datatype_t *t = (jl_datatype_t*)jl_gc_alloc_non_moving(ct->ptls, sizeof(jl_datatype_t), jl_datatype_type);
     jl_set_typetagof(t, jl_datatype_tag, 0);
     t->hash = 0;
     t->hasfreetypevars = 0;

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -414,6 +414,12 @@ JL_DLLEXPORT jl_value_t *(jl_gc_alloc)(jl_ptls_t ptls, size_t sz, void *ty)
     return jl_gc_alloc_(ptls, sz, ty);
 }
 
+JL_DLLEXPORT jl_value_t *(jl_gc_alloc_non_moving)(jl_ptls_t ptls, size_t sz, void *ty)
+{
+    return jl_gc_alloc__non_moving(ptls, sz, ty);
+}
+
+
 // Instrumented version of jl_gc_big_alloc_inner, called into by
 // LLVM-generated code.
 JL_DLLEXPORT jl_value_t *jl_gc_big_alloc(jl_ptls_t ptls, size_t sz)

--- a/src/julia.h
+++ b/src/julia.h
@@ -2483,6 +2483,11 @@ STATIC_INLINE void mmtk_immortal_post_alloc_fast(MMTkMutatorContext* mutator, vo
     }
 }
 
+STATIC_INLINE void mmtk_non_moving_post_alloc_fast(MMTkMutatorContext* mutator, void* obj, size_t size) {
+    // FIXME: do we need to call anything for non moving post alloc?
+}
+
+
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Julia types, typenames and buffers should not move. 
The first two should not move because they are used as metadata when scanning an object. The second prevents errors that may occur when arrays and other objects share the same buffer.
In order to move buffers, it would probably require checking whether it is shared during GC, i.e. buffers would have to be traced differently, perhaps through the parent object. By allocating them into a non-moving space, we can just treat them as any other  object, but this way we ensure that they don't move.

Needs to be merged with https://github.com/mmtk/mmtk-julia/pull/101.