### PR TITLE
Stop using Julia's size classes when using MMTk

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -497,8 +497,7 @@ JL_DLLEXPORT jl_value_t *jl_alloc_string(size_t len)
         s = jl_gc_pool_alloc_noinline(ptls, (char*)p - (char*)ptls, osize);
 #else
         int pool_id = jl_gc_szclass_align8(allocsz);
-        // int osize = jl_gc_sizeclasses[pool_id];
-        s = jl_mmtk_gc_alloc_default(ptls, pool_id, allocsz, jl_string_type);
+        s = jl_mmtk_gc_alloc_default(ptls, allocsz, jl_string_type);
 #endif
     }
     else {

--- a/src/array.c
+++ b/src/array.c
@@ -497,8 +497,8 @@ JL_DLLEXPORT jl_value_t *jl_alloc_string(size_t len)
         s = jl_gc_pool_alloc_noinline(ptls, (char*)p - (char*)ptls, osize);
 #else
         int pool_id = jl_gc_szclass_align8(allocsz);
-        int osize = jl_gc_sizeclasses[pool_id];
-        s = jl_mmtk_gc_alloc_default(ptls, pool_id, osize, jl_string_type);
+        // int osize = jl_gc_sizeclasses[pool_id];
+        s = jl_mmtk_gc_alloc_default(ptls, pool_id, allocsz, jl_string_type);
 #endif
     }
     else {

--- a/src/array.c
+++ b/src/array.c
@@ -496,8 +496,7 @@ JL_DLLEXPORT jl_value_t *jl_alloc_string(size_t len)
         // the Allocations Profiler. (See https://github.com/JuliaLang/julia/pull/43868 for more details.)
         s = jl_gc_pool_alloc_noinline(ptls, (char*)p - (char*)ptls, osize);
 #else
-        int pool_id = jl_gc_szclass_align8(allocsz);
-        s = jl_mmtk_gc_alloc_default(ptls, allocsz, jl_string_type);
+        s = jl_mmtk_gc_alloc_default(ptls, allocsz, 8, jl_string_type);
 #endif
     }
     else {

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -450,16 +450,6 @@ jl_value_t *jl_gc_pool_alloc_noinline(jl_ptls_t ptls, int pool_offset, int osize
     return jl_gc_pool_alloc_inner(ptls, pool_offset, osize);
 }
 
-int jl_gc_classify_pools(size_t sz, int *osize)
-{
-    if (sz > GC_MAX_SZCLASS)
-        return -1;
-    size_t allocsz = sz + sizeof(jl_taggedvalue_t);
-    int klass = jl_gc_szclass(allocsz);
-    *osize = jl_gc_sizeclasses[klass];
-    return (int)(intptr_t)(&((jl_ptls_t)0)->heap.norm_pools[klass]);
-}
-
 // TODO: jl_gc_track_malloced_array needed? Eliminate heap.mallocarrays,
 // heap.mafreelist, mallocarray_t?
 void jl_gc_track_malloced_array(jl_ptls_t ptls, jl_array_t *a) JL_NOTSAFEPOINT

--- a/src/gc.c
+++ b/src/gc.c
@@ -902,6 +902,16 @@ static NOINLINE jl_taggedvalue_t *gc_add_page(jl_gc_pool_t *p) JL_NOTSAFEPOINT
     return fl;
 }
 
+int jl_gc_classify_pools(size_t sz, int *osize)
+{
+    if (sz > GC_MAX_SZCLASS)
+        return -1;
+    size_t allocsz = sz + sizeof(jl_taggedvalue_t);
+    int klass = jl_gc_szclass(allocsz);
+    *osize = jl_gc_sizeclasses[klass];
+    return (int)(intptr_t)(&((jl_ptls_t)0)->heap.norm_pools[klass]);
+}
+
 // Size includes the tag and the tag is not cleared!!
 inline jl_value_t *jl_gc_pool_alloc_inner(jl_ptls_t ptls, int pool_offset,
                                           int osize)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -339,7 +339,7 @@ jl_value_t *jl_gc_pool_alloc_noinline(jl_ptls_t ptls, int pool_offset,
                                    int osize);
 jl_value_t *jl_gc_big_alloc_noinline(jl_ptls_t ptls, size_t allocsz);
 #ifdef MMTK_GC
-JL_DLLIMPORT jl_value_t *jl_mmtk_gc_alloc_default(jl_ptls_t ptls, int osize, void* ty);
+JL_DLLIMPORT jl_value_t *jl_mmtk_gc_alloc_default(jl_ptls_t ptls, int osize, size_t align, void* ty);
 JL_DLLIMPORT jl_value_t *jl_mmtk_gc_alloc_big(jl_ptls_t ptls, size_t allocsz);
 JL_DLLIMPORT extern void mmtk_post_alloc(void* mutator, void* obj, size_t bytes, int allocator);
 JL_DLLIMPORT extern void mmtk_initialize_collection(void* tls);
@@ -493,7 +493,7 @@ STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
     jl_value_t *v;
     const size_t allocsz = sz + sizeof(jl_taggedvalue_t);
     if (sz <= GC_MAX_SZCLASS) {
-        v = jl_mmtk_gc_alloc_default(ptls, allocsz, ty);
+        v = jl_mmtk_gc_alloc_default(ptls, allocsz, 16, ty);
     }
     else {
         if (allocsz < sz) // overflow in adding offs, size was "negative"

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -495,7 +495,7 @@ STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
     if (sz <= GC_MAX_SZCLASS) {
         int pool_id = jl_gc_szclass(allocsz);
         int osize = jl_gc_sizeclasses[pool_id];
-        v = jl_mmtk_gc_alloc_default(ptls, pool_id, osize, ty);
+        v = jl_mmtk_gc_alloc_default(ptls, pool_id, allocsz, ty);
     }
     else {
         if (allocsz < sz) // overflow in adding offs, size was "negative"

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -339,7 +339,7 @@ jl_value_t *jl_gc_pool_alloc_noinline(jl_ptls_t ptls, int pool_offset,
                                    int osize);
 jl_value_t *jl_gc_big_alloc_noinline(jl_ptls_t ptls, size_t allocsz);
 #ifdef MMTK_GC
-JL_DLLIMPORT jl_value_t *jl_mmtk_gc_alloc_default(jl_ptls_t ptls, int pool_offset, int osize, void* ty);
+JL_DLLIMPORT jl_value_t *jl_mmtk_gc_alloc_default(jl_ptls_t ptls, int osize, void* ty);
 JL_DLLIMPORT jl_value_t *jl_mmtk_gc_alloc_big(jl_ptls_t ptls, size_t allocsz);
 JL_DLLIMPORT extern void mmtk_post_alloc(void* mutator, void* obj, size_t bytes, int allocator);
 JL_DLLIMPORT extern void mmtk_initialize_collection(void* tls);
@@ -493,9 +493,7 @@ STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
     jl_value_t *v;
     const size_t allocsz = sz + sizeof(jl_taggedvalue_t);
     if (sz <= GC_MAX_SZCLASS) {
-        int pool_id = jl_gc_szclass(allocsz);
-        int osize = jl_gc_sizeclasses[pool_id];
-        v = jl_mmtk_gc_alloc_default(ptls, pool_id, allocsz, ty);
+        v = jl_mmtk_gc_alloc_default(ptls, allocsz, ty);
     }
     else {
         if (allocsz < sz) // overflow in adding offs, size was "negative"

--- a/src/mmtk-gc.c
+++ b/src/mmtk-gc.c
@@ -53,6 +53,17 @@ static inline void malloc_maybe_collect(jl_ptls_t ptls, size_t sz)
     }
 }
 
+// allocation
+int jl_gc_classify_pools(size_t sz, int *osize)
+{
+    if (sz > GC_MAX_SZCLASS)
+        return -1;
+    size_t allocsz = sz + sizeof(jl_taggedvalue_t);
+    int klass = jl_gc_szclass(allocsz);
+    *osize = LLT_ALIGN(allocsz, 16);
+    return (int)(intptr_t)(&((jl_ptls_t)0)->heap.norm_pools[klass]);
+}
+
 // malloc wrappers, aligned allocation
 // We currently just duplicate what Julia GC does. We will in the future replace the malloc calls with MMTK's malloc.
 

--- a/src/mmtk-gc.c
+++ b/src/mmtk-gc.c
@@ -168,7 +168,7 @@ inline jl_value_t *jl_gc_pool_alloc_inner(jl_ptls_t ptls, int pool_offset, int o
     // TODO: drop this okay?
     // maybe_collect(ptls);
 
-    jl_value_t *v = jl_mmtk_gc_alloc_default(ptls, pool_offset, osize, NULL);
+    jl_value_t *v = jl_mmtk_gc_alloc_default(ptls, osize, NULL);
     // TODO: this is done (without atomic operations) in jl_mmtk_gc_alloc_default; enable
     // here when that's edited?
     /*

--- a/src/mmtk-gc.c
+++ b/src/mmtk-gc.c
@@ -56,7 +56,7 @@ static inline void malloc_maybe_collect(jl_ptls_t ptls, size_t sz)
 // allocation
 int jl_gc_classify_pools(size_t sz, int *osize)
 {
-    if (sz > GC_MAX_SZCLASS) 
+    if (sz > GC_MAX_SZCLASS)
         return -1; // call big alloc function
     size_t allocsz = sz + sizeof(jl_taggedvalue_t);
     *osize = LLT_ALIGN(allocsz, 16);

--- a/src/mmtk-gc.c
+++ b/src/mmtk-gc.c
@@ -56,12 +56,11 @@ static inline void malloc_maybe_collect(jl_ptls_t ptls, size_t sz)
 // allocation
 int jl_gc_classify_pools(size_t sz, int *osize)
 {
-    if (sz > GC_MAX_SZCLASS)
-        return -1;
+    if (sz > GC_MAX_SZCLASS) 
+        return -1; // call big alloc function
     size_t allocsz = sz + sizeof(jl_taggedvalue_t);
-    int klass = jl_gc_szclass(allocsz);
     *osize = LLT_ALIGN(allocsz, 16);
-    return (int)(intptr_t)(&((jl_ptls_t)0)->heap.norm_pools[klass]);
+    return 0; // use MMTk's fastpath logic
 }
 
 // malloc wrappers, aligned allocation

--- a/src/mmtk-gc.c
+++ b/src/mmtk-gc.c
@@ -167,7 +167,7 @@ inline jl_value_t *jl_gc_pool_alloc_inner(jl_ptls_t ptls, int pool_offset, int o
     // TODO: drop this okay?
     // maybe_collect(ptls);
 
-    jl_value_t *v = jl_mmtk_gc_alloc_default(ptls, osize, NULL);
+    jl_value_t *v = jl_mmtk_gc_alloc_default(ptls, osize, 16, NULL);
     // TODO: this is done (without atomic operations) in jl_mmtk_gc_alloc_default; enable
     // here when that's edited?
     /*


### PR DESCRIPTION
When allocating an object, we are still allocating the number of bytes according to Julia's size classes, which may be an overestimation of the number of bytes an object actually requires. This PR removes this since this is specific to Julia's stock GC.