### PR TITLE
Fix binding write barrier for code gen

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3343,18 +3343,27 @@ JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p)
 
 JL_DLLEXPORT void jl_gc_wb1_noinline(const void *parent) JL_NOTSAFEPOINT
 {
+    jl_unreachable();
 }
 
 JL_DLLEXPORT void jl_gc_wb2_noinline(const void *parent, const void *ptr) JL_NOTSAFEPOINT
 {
+    jl_unreachable();
+}
+
+JL_DLLEXPORT void jl_gc_wb_binding_noinline(const void *parent, const void *ptr) JL_NOTSAFEPOINT
+{
+    jl_unreachable();
 }
 
 JL_DLLEXPORT void jl_gc_wb1_slow(const void *parent) JL_NOTSAFEPOINT
 {
+    jl_unreachable();
 }
 
 JL_DLLEXPORT void jl_gc_wb2_slow(const void *parent, const void* ptr) JL_NOTSAFEPOINT
 {
+    jl_unreachable();
 }
 
 #ifdef __cplusplus

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -193,6 +193,7 @@
     XX(jl_gc_queue_root) \
     XX(jl_gc_wb1_noinline) \
     XX(jl_gc_wb2_noinline) \
+    XX(jl_gc_wb_binding_noinline) \
     XX(jl_gc_wb1_slow) \
     XX(jl_gc_wb2_slow) \
     XX(jl_gc_safepoint) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -624,8 +624,7 @@ STATIC_INLINE void jl_gc_wb_buf(void *parent, void *bufptr, size_t minsz) JL_NOT
 
 STATIC_INLINE void jl_gc_wb_binding(jl_binding_t *bnd, void *val) JL_NOTSAFEPOINT // val isa jl_value_t*
 {
-    jl_astaggedvalue(bnd)->bits.gc = 2; // to indicate that the buffer is a binding
-    mmtk_gc_wb(bnd, val);
+    mmtk_gc_wb_binding(bnd, val);
 }
 
 STATIC_INLINE void jl_gc_wb_buf(void *parent, void *bufptr, size_t minsz) JL_NOTSAFEPOINT // parent isa jl_value_t*

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2586,8 +2586,10 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
                     }
                 }
             } else {
-                jl_printf(JL_STDERR, "ERROR: only object barrier fastpath is implemented");
-                assert(false);
+                if (MMTK_NEEDS_WRITE_BARRIER != 0) {
+                    jl_printf(JL_STDERR, "ERROR: only object barrier fastpath is implemented");
+                    assert(false);
+                }
             }
         } else {
             assert(false);

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2535,10 +2535,7 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
             assert(false);
         }
 #else
-        // FIXME: Currently we call write barrier with the src object (parent).
-        // This works fine for object barrier for generational plans (such as stickyimmix), which does not use the target object at all.
-        // But for other MMTk plans, we need to be careful.
-        const bool INLINE_WRITE_BARRIER = true;
+        const bool INLINE_WRITE_BARRIER = false;
         if (CI->getCalledOperand() == write_barrier_func || CI->getCalledOperand() == write_barrier_binding_func) {
             if (MMTK_NEEDS_WRITE_BARRIER == MMTK_OBJECT_BARRIER) {
                 if (INLINE_WRITE_BARRIER) {
@@ -2572,11 +2569,25 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
                     SmallVector<uint32_t, 2> Weights{1, 9};
                     auto mayTriggerSlowpath = SplitBlockAndInsertIfThen(is_unlogged, CI, false, MDB.createBranchWeights(Weights));
                     builder.SetInsertPoint(mayTriggerSlowpath);
+                    // We just need the src object (parent)
                     builder.CreateCall(getOrDeclare(jl_intrinsics::writeBarrier1Slow), { parent });
                 } else {
-                    Function *wb_func = getOrDeclare(jl_intrinsics::writeBarrier1);
-                    builder.CreateCall(wb_func, { parent });
+                    // Do not inlie write barrier -- just call into each function.
+                    // For object remembering barrier, we just need the src object (parent)
+                    if (CI->getCalledOperand() == write_barrier_func) {
+                        Function *wb_func = getOrDeclare(jl_intrinsics::writeBarrier1);
+                        builder.CreateCall(wb_func, { parent });
+                    } else {
+                        assert(CI->getCalledOperand() == write_barrier_binding_func);
+                        assert(CI->arg_size() == 2);
+                        auto val = CI->getArgOperand(1);
+                        Function *wb_func = getOrDeclare(jl_intrinsics::writeBarrierBinding);
+                        builder.CreateCall(wb_func, { parent, val });
+                    }
                 }
+            } else {
+                jl_printf(JL_STDERR, "ERROR: only object barrier fastpath is implemented");
+                assert(false);
             }
         } else {
             assert(false);

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -123,6 +123,7 @@ namespace jl_intrinsics {
 #ifdef MMTK_GC
     static const char *WRITE_BARRIER_1_NAME = "julia.write_barrier1_noinline";
     static const char *WRITE_BARRIER_2_NAME = "julia.write_barrier2_noinline";
+    static const char *WRITE_BARRIER_BINDING_NAME = "julia.write_barrier_binding_noinline";
     static const char *WRITE_BARRIER_1_SLOW_NAME = "julia.write_barrier_1_slow";
     static const char *WRITE_BARRIER_2_SLOW_NAME = "julia.write_barrier_2_slow";
 #endif
@@ -281,6 +282,20 @@ namespace jl_intrinsics {
             intrinsic->addFnAttr(Attribute::InaccessibleMemOrArgMemOnly);
             return intrinsic;
         });
+    const IntrinsicDescription writeBarrierBinding(
+        WRITE_BARRIER_BINDING_NAME,
+        [](const JuliaPassContext &context) {
+            auto T_prjlvalue = JuliaType::get_prjlvalue_ty(context.getLLVMContext());
+            auto intrinsic = Function::Create(
+                FunctionType::get(
+                    Type::getVoidTy(context.getLLVMContext()),
+                    { T_prjlvalue, T_prjlvalue },
+                    false),
+                Function::ExternalLinkage,
+                WRITE_BARRIER_BINDING_NAME);
+            intrinsic->addFnAttr(Attribute::InaccessibleMemOrArgMemOnly);
+            return intrinsic;
+        });
     const IntrinsicDescription writeBarrier1Slow(
         WRITE_BARRIER_1_SLOW_NAME,
         [](const JuliaPassContext &context) {
@@ -321,6 +336,7 @@ namespace jl_well_known {
 #ifdef MMTK_GC
     static const char *GC_WB_1_NAME = XSTR(jl_gc_wb1_noinline);
     static const char *GC_WB_2_NAME = XSTR(jl_gc_wb2_noinline);
+    static const char *GC_WB_BINDING_NAME = XSTR(jl_gc_wb_binding_noinline);
     static const char *GC_WB_1_SLOW_NAME = XSTR(jl_gc_wb1_slow);
     static const char *GC_WB_2_SLOW_NAME = XSTR(jl_gc_wb2_slow);
 #endif
@@ -434,6 +450,21 @@ namespace jl_well_known {
                     false),
                 Function::ExternalLinkage,
                 GC_WB_2_NAME);
+            func->addFnAttr(Attribute::InaccessibleMemOrArgMemOnly);
+            return func;
+    });
+
+    const WellKnownFunctionDescription GCWriteBarrierBinding(
+        GC_WB_BINDING_NAME,
+        [](const JuliaPassContext &context) {
+            auto T_prjlvalue = JuliaType::get_prjlvalue_ty(context.getLLVMContext());
+            auto func = Function::Create(
+                FunctionType::get(
+                    Type::getVoidTy(context.getLLVMContext()),
+                    { T_prjlvalue, T_prjlvalue },
+                    false),
+                Function::ExternalLinkage,
+                GC_WB_BINDING_NAME);
             func->addFnAttr(Attribute::InaccessibleMemOrArgMemOnly);
             return func;
     });

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -136,6 +136,7 @@ namespace jl_intrinsics {
 #ifdef MMTK_GC
     extern const IntrinsicDescription writeBarrier1;
     extern const IntrinsicDescription writeBarrier2;
+    extern const IntrinsicDescription writeBarrierBinding;
     extern const IntrinsicDescription writeBarrier1Slow;
     extern const IntrinsicDescription writeBarrier2Slow;
 #endif
@@ -169,6 +170,7 @@ namespace jl_well_known {
 #ifdef MMTK_GC
     extern const WellKnownFunctionDescription GCWriteBarrier1;
     extern const WellKnownFunctionDescription GCWriteBarrier2;
+    extern const WellKnownFunctionDescription GCWriteBarrierBinding;
     extern const WellKnownFunctionDescription GCWriteBarrier1Slow;
     extern const WellKnownFunctionDescription GCWriteBarrier2Slow;
 #endif

--- a/src/mmtk-gc.c
+++ b/src/mmtk-gc.c
@@ -240,6 +240,7 @@ JL_DLLEXPORT void jl_gc_queue_multiroot(const jl_value_t *parent, const jl_value
 
 JL_DLLEXPORT void jl_gc_queue_binding(jl_binding_t *bnd)
 {
+    mmtk_unreachable();
 }
 
 

--- a/src/mmtk-gc.c
+++ b/src/mmtk-gc.c
@@ -566,6 +566,11 @@ JL_DLLEXPORT void jl_gc_wb2_noinline(const void *parent, const void *ptr) JL_NOT
     jl_gc_wb(parent, ptr);
 }
 
+JL_DLLEXPORT void jl_gc_wb_binding_noinline(const void *bnd, const void *val) JL_NOTSAFEPOINT
+{
+    jl_gc_wb_binding((jl_binding_t*)bnd, (void*)val);
+}
+
 JL_DLLEXPORT void jl_gc_wb1_slow(const void *parent) JL_NOTSAFEPOINT
 {
     jl_task_t *ct = jl_current_task;


### PR DESCRIPTION
This PR makes a few changes about write barrier for bindings.
* Move the code that sets gc bits to 2 in the binding write barrier into the slowpath
* Generate code to set gc bits for binding write barrier.
* Add `unreachable()` in a few `jl_gc_wb` methods in Julia to make sure they won't be accidentally called (Julia's GC does not inline write barrier, and won't need them).