### PR TITLE
Implement fixed heap size for Julia

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -85,7 +85,9 @@ HAVE_SSP := 0
 # GC debugging options
 WITH_GC_VERIFY := 0
 WITH_GC_DEBUG_ENV := 0
-WITH_GC_FIXED_HEAP := 0
+
+# Overwrite Julia's GC heuristics and only trigger a GC if the heap is full (fixed_heap_size needs to be set in this build)
+WITH_GC_FIXED_HEAP ?= 0
 
 # MMTk GC
 WITH_MMTK ?= 0

--- a/Make.inc
+++ b/Make.inc
@@ -85,6 +85,7 @@ HAVE_SSP := 0
 # GC debugging options
 WITH_GC_VERIFY := 0
 WITH_GC_DEBUG_ENV := 0
+WITH_GC_FIXED_HEAP := 0
 
 # MMTk GC
 WITH_MMTK ?= 0
@@ -736,6 +737,11 @@ endif
 ifeq ($(WITH_GC_DEBUG_ENV), 1)
 JCXXFLAGS += -DGC_DEBUG_ENV
 JCFLAGS += -DGC_DEBUG_ENV
+endif
+
+ifeq ($(WITH_GC_FIXED_HEAP), 1)
+JCXXFLAGS += -DGC_FIXED_HEAP
+JCFLAGS += -DGC_FIXED_HEAP
 endif
 
 ifeq ($(WITH_MMTK), 1)

--- a/base/options.jl
+++ b/base/options.jl
@@ -56,6 +56,7 @@ struct JLOptions
     strip_ir::Int8
     permalloc_pkgimg::Int8
     heap_size_hint::UInt64
+    fixed_heap_size::UInt64
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/src/gc.c
+++ b/src/gc.c
@@ -3075,6 +3075,8 @@ void jl_gc_init(void)
     if (jl_options.fixed_heap_size) {
         // This guarantees that we will not trigger a GC before reaching heap limit
         gc_num.interval = jl_options.fixed_heap_size;
+    } else {
+        jl_printf(JL_STDERR, "Warning: The option fixed-heap-size is not set for a build with WITH_GC_FIXED_HEAP\n");
     }
 #endif
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -584,7 +584,6 @@ inline void maybe_collect(jl_ptls_t ptls)
         uint64_t current_heap_size = ((uint64_t)jl_current_pg_count()) << (uint64_t)14;
         current_heap_size += jl_atomic_load_relaxed(&malloc_bytes);
         if (current_heap_size >= jl_options.fixed_heap_size) {
-            printf("GC: fixed heap size = %ld, current heap size = %ld\n", jl_options.fixed_heap_size, current_heap_size);
             jl_gc_collect(JL_GC_AUTO);
         } else {
             jl_gc_safepoint_(ptls);
@@ -2720,7 +2719,6 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
         sweep_full = 1;
     }
     if (sweep_full) {
-        printf("Full sweep\n");
         // these are the difference between the number of gc-perm bytes scanned
         // on the first collection after sweep_full, and the current scan
         perm_scanned_bytes = 0;

--- a/src/gc.c
+++ b/src/gc.c
@@ -2724,6 +2724,10 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
         sweep_full = 1;
         recollect = 1;
     }
+    if (jl_options.fixed_heap_size) {
+        // For fixed heap size, do not trigger full sweep for any other heuristics
+        sweep_full = 0;
+    }
     if (next_sweep_full) {
         next_sweep_full = 0;
         sweep_full = 1;

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -60,6 +60,7 @@ typedef struct {
     int8_t strip_ir;
     int8_t permalloc_pkgimg;
     uint64_t heap_size_hint;
+    uint64_t fixed_heap_size;
 } jl_options_t;
 
 #endif


### PR DESCRIPTION
This PR introduces fixed heap size for stock Julia. With the build time option `WITH_GC_FIXED_HEAP=1` and using `--fixed-heap-size=...`, it will bypass all the existing GC triggering heuristics, and only do GC when the heap size reaches the defined heap size, and will only do a full heap GC if the free memory after a GC is less than 20% of the heap size.

This PR also introduces a global counter for mallocd bytes. This will slow down the performance of malloc. For MMTK Julia, we also use such a counter (see https://github.com/mmtk/mmtk-julia/issues/141). I plan to do another PR to fix this for both MMTK Julia and stock Julia.