### PR TITLE
Call initialize_collection after _finish_julia_init

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -798,10 +798,6 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 
     jl_ptls_t ptls = jl_init_threadtls(0);
 
-#ifdef MMTK_GC
-    mmtk_initialize_collection((void *)ptls);
-#endif
-
 #pragma GCC diagnostic push
 #if defined(_COMPILER_GCC_) && __GNUC__ >= 12
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
@@ -811,6 +807,10 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 #pragma GCC diagnostic pop
     JL_GC_PROMISE_ROOTED(ct);
     _finish_julia_init(rel, ptls, ct);
+
+#ifdef MMTK_GC
+    mmtk_initialize_collection((void *)ptls);
+#endif
 }
 
 void jl_init_heartbeat(void);


### PR DESCRIPTION
Calling `initialize_collection` means the language runtime is ready to do GCs. However, if I attempt to trigger a GC at the end of `initialize_collection`, the current code would fail due to two issues: 1. We cannot call `get_current_task` and `get_current_ptls`, as those are not initialized yet, and 2. some objects may get reclaimed and cause segfault if we run `julia -J sys_image.so`.

Moving the call to `initialize_collection` as the last step in `julia_init` fixes the issues.