### PR TITLE
Adding macros to push pinning roots

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -54,10 +54,10 @@ extern void JL_GC_ENABLEFRAME(interpreter_state*) JL_NOTSAFEPOINT;
 #ifdef MMTK_GC
 #define JL_GC_ENCODE_PUSHFRAME(n)  ((((size_t)(n))<<3)|2)
 // For roots that are not transitively pinned
-#define JL_GC_ENCODE_PUSHFRAME_RELAXED(n)  ((((size_t)(n))<<3)|6)
+#define JL_GC_ENCODE_PUSHFRAME_NO_TPIN(n)  ((((size_t)(n))<<3)|6)
 #else
 #define JL_GC_ENCODE_PUSHFRAME(n)  ((((size_t)(n))<<2)|2)
-#define JL_GC_ENCODE_PUSHFRAME_RELAXED(n)  JL_GC_ENCODE_PUSHFRAME(n)
+#define JL_GC_ENCODE_PUSHFRAME_NO_TPIN(n)  JL_GC_ENCODE_PUSHFRAME(n)
 #endif
 
 #define JL_GC_PUSHFRAME(frame,locals,n)                                             \

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -51,7 +51,14 @@ extern void JL_GC_ENABLEFRAME(interpreter_state*) JL_NOTSAFEPOINT;
 
 #else
 
+#ifdef MMTK_GC
+#define JL_GC_ENCODE_PUSHFRAME(n)  ((((size_t)(n))<<3)|2)
+// For roots that are not transitively pinned
+#define JL_GC_ENCODE_PUSHFRAME_RELAXED(n)  ((((size_t)(n))<<3)|6)
+#else
 #define JL_GC_ENCODE_PUSHFRAME(n)  ((((size_t)(n))<<2)|2)
+#define JL_GC_ENCODE_PUSHFRAME_RELAXED(n)  JL_GC_ENCODE_PUSHFRAME(n)
+#endif
 
 #define JL_GC_PUSHFRAME(frame,locals,n)                                             \
   JL_CPPALLOCA(frame, sizeof(*frame)+(((n)+3)*sizeof(jl_value_t*)));                \

--- a/src/julia.h
+++ b/src/julia.h
@@ -852,8 +852,21 @@ struct _jl_gcframe_t {
 
 #define jl_pgcstack (jl_current_task->gcstack)
 
+#ifndef MMTK_GC
 #define JL_GC_ENCODE_PUSHARGS(n)   (((size_t)(n))<<2)
 #define JL_GC_ENCODE_PUSH(n)       ((((size_t)(n))<<2)|1)
+
+#define JL_GC_ENCODE_PUSHARGS_RELAXED(n)  JL_GC_ENCODE_PUSHARGS(n)
+#define JL_GC_ENCODE_PUSH_RELAXED(n)      JL_GC_ENCODE_PUSH_RELAXED(n)
+#else
+// these are transitively pinning
+#define JL_GC_ENCODE_PUSHARGS(n)   (((size_t)(n))<<3)
+#define JL_GC_ENCODE_PUSH(n)       ((((size_t)(n))<<3)|1)
+
+// these only pin the root object itself
+#define JL_GC_ENCODE_PUSHARGS_RELAXED(n)   (((size_t)(n))<<3|4)
+#define JL_GC_ENCODE_PUSH_RELAXED(n)       ((((size_t)(n))<<3)|5)
+#endif
 
 #ifdef __clang_gcanalyzer__
 
@@ -905,10 +918,10 @@ extern void JL_GC_POP() JL_NOTSAFEPOINT;
 #define JL_GC_PUSH7(arg1, arg2, arg3, arg4, arg5, arg6, arg7)                                           \
   void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH(7), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7}; \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+
 #define JL_GC_PUSH8(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)                                     \
   void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH(8), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8}; \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
-
 
 #define JL_GC_PUSHARGS(rts_var,n)                                                                       \
   rts_var = ((jl_value_t**)alloca(((n)+2)*sizeof(jl_value_t*)))+2;                                      \
@@ -919,6 +932,68 @@ extern void JL_GC_POP() JL_NOTSAFEPOINT;
 
 #define JL_GC_POP() (jl_pgcstack = jl_pgcstack->prev)
 
+#endif
+
+#ifdef MMTK_GC
+// these are pinning roots: only the root object needs to be pinned as opposed to
+// the functions above which are transitively pinning
+#define JL_GC_PUSH1_RELAXED(arg1)                                                                                     \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(1), jl_pgcstack, arg1};                                  \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+
+#define JL_GC_PUSH2_RELAXED(arg1, arg2)                                                                               \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(2), jl_pgcstack, arg1, arg2};                            \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+
+#define JL_GC_PUSH3_RELAXED(arg1, arg2, arg3)                                                                         \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(3), jl_pgcstack, arg1, arg2, arg3};                       \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+
+#define JL_GC_PUSH4_RELAXED(arg1, arg2, arg3, arg4)                                                                   \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(4), jl_pgcstack, arg1, arg2, arg3, arg4};                \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+
+#define JL_GC_PUSH5_RELAXED(arg1, arg2, arg3, arg4, arg5)                                                             \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(5), jl_pgcstack, arg1, arg2, arg3, arg4, arg5};           \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+
+#define JL_GC_PUSH6_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6)                                                       \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(6), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6};     \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+
+#define JL_GC_PUSH7_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6, arg7)                                                    \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(7), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7};  \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+
+#define JL_GC_PUSH8_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)                                     \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(8), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8}; \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+
+#define JL_GC_PUSHARGS_RELAXED(rts_var,n)                                                                       \
+  rts_var = ((jl_value_t**)alloca(((n)+2)*sizeof(jl_value_t*)))+2;                                      \
+  ((void**)rts_var)[-2] = (void*)JL_GC_ENCODE_PUSHARGS_RELAXED(n);                                              \
+  ((void**)rts_var)[-1] = jl_pgcstack;                                                                  \
+  memset((void*)rts_var, 0, (n)*sizeof(jl_value_t*));                                                   \
+  jl_pgcstack = (jl_gcframe_t*)&(((void**)rts_var)[-2])
+#else
+// When not using MMTk, default to the stock functions
+#define JL_GC_PUSH1_RELAXED(arg1) JL_GC_PUSH1(arg1) 
+
+#define JL_GC_PUSH2_RELAXED(arg1, arg2) JL_GC_PUSH2(arg1, arg2)
+
+#define JL_GC_PUSH3_RELAXED(arg1, arg2, arg3) JL_GC_PUSH3(arg1, arg2, arg3)    
+
+#define JL_GC_PUSH4_RELAXED(arg1, arg2, arg3, arg4) JL_GC_PUSH4(arg1, arg2, arg3, arg4)
+
+#define JL_GC_PUSH5_RELAXED(arg1, arg2, arg3, arg4, arg5) JL_GC_PUSH5(arg1, arg2, arg3, arg4, arg5)
+
+#define JL_GC_PUSH6_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6) JL_GC_PUSH6(arg1, arg2, arg3, arg4, arg5, arg6) 
+
+#define JL_GC_PUSH7_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6, arg7) JL_GC_PUSH7(arg1, arg2, arg3, arg4, arg5, arg6, arg7) 
+
+#define JL_GC_PUSH8_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) JL_GC_PUSH8(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+
+#define JL_GC_PUSHARGS_RELAXED(rts_var,n) JL_GC_PUSHARGS(rts_var,n)
 #endif
 
 JL_DLLEXPORT int jl_gc_enable(int on);

--- a/src/julia.h
+++ b/src/julia.h
@@ -859,6 +859,24 @@ struct _jl_gcframe_t {
 #define JL_GC_ENCODE_PUSHARGS_NO_TPIN(n)  JL_GC_ENCODE_PUSHARGS(n)
 #define JL_GC_ENCODE_PUSH_NO_TPIN(n)      JL_GC_ENCODE_PUSH(n)
 #else
+
+// We use an extra bit (100) in the nroots value from the frame to indicate that the roots 
+// in the frame are/are not transitively pinning.
+// There are currently 3 macros that encode passing nroots to the gcframe 
+// and they use the two lowest bits to encode information about what is in the frame (as below).
+// To support the distinction between transtively pinning roots and non transitively pinning roots
+// on the stack, we take another bit from nroots to encode information about whether or not to 
+// transitively pin the roots in the frame.
+// 
+// So the ones that transitively pin look like:
+// #define JL_GC_ENCODE_PUSHARGS(n)   (((size_t)(n))<<3)
+// #define JL_GC_ENCODE_PUSH(n)       ((((size_t)(n))<<3)|1)
+// #define JL_GC_ENCODE_PUSHFRAME(n)  ((((size_t)(n))<<3)|2)
+// and the ones that do not look like:
+// #define JL_GC_ENCODE_PUSHARGS_NO_TPIN(n)   (((size_t)(n))<<3|4)
+// #define JL_GC_ENCODE_PUSH_NO_TPIN(n)       ((((size_t)(n))<<3)|5)
+// #define JL_GC_ENCODE_PUSHFRAME_NO_TPIN(n)  ((((size_t)(n))<<3)|6)
+
 // these are transitively pinning
 #define JL_GC_ENCODE_PUSHARGS(n)   (((size_t)(n))<<3)
 #define JL_GC_ENCODE_PUSH(n)       ((((size_t)(n))<<3)|1)

--- a/src/julia.h
+++ b/src/julia.h
@@ -977,19 +977,19 @@ extern void JL_GC_POP() JL_NOTSAFEPOINT;
   jl_pgcstack = (jl_gcframe_t*)&(((void**)rts_var)[-2])
 #else
 // When not using MMTk, default to the stock functions
-#define JL_GC_PUSH1_NO_TPIN(arg1) JL_GC_PUSH1(arg1) 
+#define JL_GC_PUSH1_NO_TPIN(arg1) JL_GC_PUSH1(arg1)
 
 #define JL_GC_PUSH2_NO_TPIN(arg1, arg2) JL_GC_PUSH2(arg1, arg2)
 
-#define JL_GC_PUSH3_NO_TPIN(arg1, arg2, arg3) JL_GC_PUSH3(arg1, arg2, arg3)    
+#define JL_GC_PUSH3_NO_TPIN(arg1, arg2, arg3) JL_GC_PUSH3(arg1, arg2, arg3)
 
 #define JL_GC_PUSH4_NO_TPIN(arg1, arg2, arg3, arg4) JL_GC_PUSH4(arg1, arg2, arg3, arg4)
 
 #define JL_GC_PUSH5_NO_TPIN(arg1, arg2, arg3, arg4, arg5) JL_GC_PUSH5(arg1, arg2, arg3, arg4, arg5)
 
-#define JL_GC_PUSH6_NO_TPIN(arg1, arg2, arg3, arg4, arg5, arg6) JL_GC_PUSH6(arg1, arg2, arg3, arg4, arg5, arg6) 
+#define JL_GC_PUSH6_NO_TPIN(arg1, arg2, arg3, arg4, arg5, arg6) JL_GC_PUSH6(arg1, arg2, arg3, arg4, arg5, arg6)
 
-#define JL_GC_PUSH7_NO_TPIN(arg1, arg2, arg3, arg4, arg5, arg6, arg7) JL_GC_PUSH7(arg1, arg2, arg3, arg4, arg5, arg6, arg7) 
+#define JL_GC_PUSH7_NO_TPIN(arg1, arg2, arg3, arg4, arg5, arg6, arg7) JL_GC_PUSH7(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 
 #define JL_GC_PUSH8_NO_TPIN(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) JL_GC_PUSH8(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -856,16 +856,16 @@ struct _jl_gcframe_t {
 #define JL_GC_ENCODE_PUSHARGS(n)   (((size_t)(n))<<2)
 #define JL_GC_ENCODE_PUSH(n)       ((((size_t)(n))<<2)|1)
 
-#define JL_GC_ENCODE_PUSHARGS_RELAXED(n)  JL_GC_ENCODE_PUSHARGS(n)
-#define JL_GC_ENCODE_PUSH_RELAXED(n)      JL_GC_ENCODE_PUSH_RELAXED(n)
+#define JL_GC_ENCODE_PUSHARGS_NO_TPIN(n)  JL_GC_ENCODE_PUSHARGS(n)
+#define JL_GC_ENCODE_PUSH_NO_TPIN(n)      JL_GC_ENCODE_PUSH(n)
 #else
 // these are transitively pinning
 #define JL_GC_ENCODE_PUSHARGS(n)   (((size_t)(n))<<3)
 #define JL_GC_ENCODE_PUSH(n)       ((((size_t)(n))<<3)|1)
 
 // these only pin the root object itself
-#define JL_GC_ENCODE_PUSHARGS_RELAXED(n)   (((size_t)(n))<<3|4)
-#define JL_GC_ENCODE_PUSH_RELAXED(n)       ((((size_t)(n))<<3)|5)
+#define JL_GC_ENCODE_PUSHARGS_NO_TPIN(n)   (((size_t)(n))<<3|4)
+#define JL_GC_ENCODE_PUSH_NO_TPIN(n)       ((((size_t)(n))<<3)|5)
 #endif
 
 #ifdef __clang_gcanalyzer__
@@ -937,63 +937,63 @@ extern void JL_GC_POP() JL_NOTSAFEPOINT;
 #ifdef MMTK_GC
 // these are pinning roots: only the root object needs to be pinned as opposed to
 // the functions above which are transitively pinning
-#define JL_GC_PUSH1_RELAXED(arg1)                                                                                     \
-  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(1), jl_pgcstack, arg1};                                  \
+#define JL_GC_PUSH1_NO_TPIN(arg1)                                                                                     \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_NO_TPIN(1), jl_pgcstack, arg1};                                  \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 
-#define JL_GC_PUSH2_RELAXED(arg1, arg2)                                                                               \
-  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(2), jl_pgcstack, arg1, arg2};                            \
+#define JL_GC_PUSH2_NO_TPIN(arg1, arg2)                                                                               \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_NO_TPIN(2), jl_pgcstack, arg1, arg2};                            \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 
-#define JL_GC_PUSH3_RELAXED(arg1, arg2, arg3)                                                                         \
-  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(3), jl_pgcstack, arg1, arg2, arg3};                       \
+#define JL_GC_PUSH3_NO_TPIN(arg1, arg2, arg3)                                                                         \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_NO_TPIN(3), jl_pgcstack, arg1, arg2, arg3};                       \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 
-#define JL_GC_PUSH4_RELAXED(arg1, arg2, arg3, arg4)                                                                   \
-  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(4), jl_pgcstack, arg1, arg2, arg3, arg4};                \
+#define JL_GC_PUSH4_NO_TPIN(arg1, arg2, arg3, arg4)                                                                   \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_NO_TPIN(4), jl_pgcstack, arg1, arg2, arg3, arg4};                \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 
-#define JL_GC_PUSH5_RELAXED(arg1, arg2, arg3, arg4, arg5)                                                             \
-  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(5), jl_pgcstack, arg1, arg2, arg3, arg4, arg5};           \
+#define JL_GC_PUSH5_NO_TPIN(arg1, arg2, arg3, arg4, arg5)                                                             \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_NO_TPIN(5), jl_pgcstack, arg1, arg2, arg3, arg4, arg5};           \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 
-#define JL_GC_PUSH6_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6)                                                       \
-  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(6), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6};     \
+#define JL_GC_PUSH6_NO_TPIN(arg1, arg2, arg3, arg4, arg5, arg6)                                                       \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_NO_TPIN(6), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6};     \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 
-#define JL_GC_PUSH7_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6, arg7)                                                    \
-  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(7), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7};  \
+#define JL_GC_PUSH7_NO_TPIN(arg1, arg2, arg3, arg4, arg5, arg6, arg7)                                                    \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_NO_TPIN(7), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7};  \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 
-#define JL_GC_PUSH8_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)                                     \
-  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_RELAXED(8), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8}; \
+#define JL_GC_PUSH8_NO_TPIN(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)                                     \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH_NO_TPIN(8), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8}; \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 
-#define JL_GC_PUSHARGS_RELAXED(rts_var,n)                                                                       \
+#define JL_GC_PUSHARGS_NO_TPIN(rts_var,n)                                                                       \
   rts_var = ((jl_value_t**)alloca(((n)+2)*sizeof(jl_value_t*)))+2;                                      \
-  ((void**)rts_var)[-2] = (void*)JL_GC_ENCODE_PUSHARGS_RELAXED(n);                                              \
+  ((void**)rts_var)[-2] = (void*)JL_GC_ENCODE_PUSHARGS_NO_TPIN(n);                                              \
   ((void**)rts_var)[-1] = jl_pgcstack;                                                                  \
   memset((void*)rts_var, 0, (n)*sizeof(jl_value_t*));                                                   \
   jl_pgcstack = (jl_gcframe_t*)&(((void**)rts_var)[-2])
 #else
 // When not using MMTk, default to the stock functions
-#define JL_GC_PUSH1_RELAXED(arg1) JL_GC_PUSH1(arg1) 
+#define JL_GC_PUSH1_NO_TPIN(arg1) JL_GC_PUSH1(arg1) 
 
-#define JL_GC_PUSH2_RELAXED(arg1, arg2) JL_GC_PUSH2(arg1, arg2)
+#define JL_GC_PUSH2_NO_TPIN(arg1, arg2) JL_GC_PUSH2(arg1, arg2)
 
-#define JL_GC_PUSH3_RELAXED(arg1, arg2, arg3) JL_GC_PUSH3(arg1, arg2, arg3)    
+#define JL_GC_PUSH3_NO_TPIN(arg1, arg2, arg3) JL_GC_PUSH3(arg1, arg2, arg3)    
 
-#define JL_GC_PUSH4_RELAXED(arg1, arg2, arg3, arg4) JL_GC_PUSH4(arg1, arg2, arg3, arg4)
+#define JL_GC_PUSH4_NO_TPIN(arg1, arg2, arg3, arg4) JL_GC_PUSH4(arg1, arg2, arg3, arg4)
 
-#define JL_GC_PUSH5_RELAXED(arg1, arg2, arg3, arg4, arg5) JL_GC_PUSH5(arg1, arg2, arg3, arg4, arg5)
+#define JL_GC_PUSH5_NO_TPIN(arg1, arg2, arg3, arg4, arg5) JL_GC_PUSH5(arg1, arg2, arg3, arg4, arg5)
 
-#define JL_GC_PUSH6_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6) JL_GC_PUSH6(arg1, arg2, arg3, arg4, arg5, arg6) 
+#define JL_GC_PUSH6_NO_TPIN(arg1, arg2, arg3, arg4, arg5, arg6) JL_GC_PUSH6(arg1, arg2, arg3, arg4, arg5, arg6) 
 
-#define JL_GC_PUSH7_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6, arg7) JL_GC_PUSH7(arg1, arg2, arg3, arg4, arg5, arg6, arg7) 
+#define JL_GC_PUSH7_NO_TPIN(arg1, arg2, arg3, arg4, arg5, arg6, arg7) JL_GC_PUSH7(arg1, arg2, arg3, arg4, arg5, arg6, arg7) 
 
-#define JL_GC_PUSH8_RELAXED(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) JL_GC_PUSH8(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+#define JL_GC_PUSH8_NO_TPIN(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) JL_GC_PUSH8(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 
-#define JL_GC_PUSHARGS_RELAXED(rts_var,n) JL_GC_PUSHARGS(rts_var,n)
+#define JL_GC_PUSHARGS_NO_TPIN(rts_var,n) JL_GC_PUSHARGS(rts_var,n)
 #endif
 
 JL_DLLEXPORT int jl_gc_enable(int on);


### PR DESCRIPTION
Supporting pushing roots to the shadow stack that are not transitively pinned (only the root object is pinned), and therefore should enable moving more objects.

For backwards compatibility the original functions will be used to represent transitively pinned roots, whereas the `*_RELAXED` version will represent roots in which only the root object needs to be pinned. Therefore, to support moving move objects the goal is to replace as much as possible of the original functions with their `_RELAXED` counterpart.