### PR TITLE
Call initialize_collection before enabling GC

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -807,10 +807,6 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 #pragma GCC diagnostic pop
     JL_GC_PROMISE_ROOTED(ct);
     _finish_julia_init(rel, ptls, ct);
-
-#ifdef MMTK_GC
-    mmtk_initialize_collection((void *)ptls);
-#endif
 }
 
 void jl_init_heartbeat(void);
@@ -857,6 +853,9 @@ static NOINLINE void _finish_julia_init(JL_IMAGE_SEARCH rel, jl_ptls_t ptls, jl_
 
     jl_init_heartbeat();
 
+#ifdef MMTK_GC
+    mmtk_initialize_collection((void *)ptls);
+#endif
     jl_gc_enable(1);
 
     if (jl_options.image_file && (!jl_generating_output() || jl_options.incremental) && jl_module_init_order) {


### PR DESCRIPTION
This PR fixes https://github.com/mmtk/mmtk-core/issues/1096. We should call `initialize_collection` before enabling GC. Related discussion here: https://github.com/mmtk/julia/pull/39#discussion_r1503650745