### PR TITLE
Fix a few places where GC static analyzer will report as errors

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -47,7 +47,7 @@ extern void jl_rng_split(uint64_t to[4], uint64_t from[4]);
 extern void gc_premark(jl_ptls_t ptls2);
 extern void *gc_managed_realloc_(jl_ptls_t ptls, void *d, size_t sz, size_t oldsz,
                                  int isaligned, jl_value_t *owner, int8_t can_collect);
-extern size_t jl_array_nbytes(jl_array_t *a);
+extern size_t jl_array_nbytes(jl_array_t *a) JL_NOTSAFEPOINT;
 extern void run_finalizers(jl_task_t *ct);
 
 #ifdef OBJPROFILE

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -20,7 +20,7 @@ extern "C" {
 #endif
 
 
-JL_DLLEXPORT int16_t jl_threadid(void);
+JL_DLLEXPORT int16_t jl_threadid(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int8_t jl_threadpoolid(int16_t tid) JL_NOTSAFEPOINT;
 
 // JULIA_ENABLE_THREADING may be controlled by altering JULIA_THREADS in Make.user

--- a/src/threading.c
+++ b/src/threading.c
@@ -309,7 +309,7 @@ static uv_cond_t cond;
 // it is implemented separately because the API of direct jl_all_tls_states use is already widely prevalent
 
 // return calling thread's ID
-JL_DLLEXPORT int16_t jl_threadid(void)
+JL_DLLEXPORT int16_t jl_threadid(void) JL_NOTSAFEPOINT
 {
     return jl_atomic_load_relaxed(&jl_current_task->tid);
 }


### PR DESCRIPTION
These functions do not include GC safe points. But without marking them as `JL_NOTSAFEPOINT`, the GC checker will report errors in other places.