### PR TITLE
WIP: save registers of tasks that were active right before GC on a ucontext_t for conservative scanning

### DIFF
--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -968,3 +968,19 @@ static int gc_logging_enabled = 0;
 JL_DLLEXPORT void jl_enable_gc_logging(int enable) {
     gc_logging_enabled = enable;
 }
+
+JL_DLLEXPORT void jl_save_context_for_conservative_scanning(jl_ptls_t ptls, void *ctx)
+{
+#ifdef GC_SAVE_CONTEXT_FOR_CONSERVATIVE_SCANNING
+    if (ctx == NULL) {
+        // Save the context for the thread as it was running at the time of the call
+        int r = getcontext(&ptls->ctx_at_the_time_gc_started);
+        if (r == -1) {
+            jl_safe_printf("Failed to save context for conservative scanning\n");
+            abort();
+        }
+        return;
+    }
+    memcpy(&ptls->ctx_at_the_time_gc_started, ctx, sizeof(ucontext_t));
+#endif
+}

--- a/src/gc.c
+++ b/src/gc.c
@@ -2716,6 +2716,7 @@ size_t jl_maxrss(void);
 // Only one thread should be running in this function
 static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
 {
+    jl_save_context_for_conservative_scanning(ptls, NULL);
     combine_thread_gc_counts(&gc_num);
 
     jl_gc_markqueue_t *mq = &ptls->mark_queue;

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -152,6 +152,12 @@ JL_DLLEXPORT void jl_active_task_stack(jl_task_t *task,
                                        char **active_start, char **active_end,
                                        char **total_start, char **total_end);
 
+// Save the context of a task for conservative scanning.
+// Requires `GC_SAVE_CONTEXT_FOR_CONSERVATIVE_SCANNING` to be defined.
+// If ctx is NULL, the registers of the thread at the moment of the call are saved, else
+// the registers of the context ctx are saved into the `ctx_at_the_time_gc_started` field of Julia's TLS.
+JL_DLLEXPORT void jl_save_context_for_conservative_scanning(jl_ptls_t ptls, void *ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -282,6 +282,10 @@ typedef struct _jl_tls_states_t {
     size_t malloc_sz_since_last_poll;
 #endif
 
+#ifdef GC_SAVE_CONTEXT_FOR_CONSERVATIVE_SCANNING
+    ucontext_t ctx_at_the_time_gc_started;
+#endif
+
     JULIA_DEBUG_SLEEPWAKE(
         uint64_t uv_run_enter;
         uint64_t uv_run_leave;

--- a/src/options.h
+++ b/src/options.h
@@ -86,6 +86,13 @@
 // GC_SMALL_PAGE allocates objects in 4k pages
 // #define GC_SMALL_PAGE
 
+// GC_SAVE_CONTEXT_FOR_CONSERVATIVE_SCANNING saves the context of the tasks that
+// were running right before GC started so that they can be used for conservative
+// scanning. Currently only available on x86_64 Linux.
+#define GC_SAVE_CONTEXT_FOR_CONSERVATIVE_SCANNING
+#if !defined(x86_64) || !defined(_OS_LINUX_)
+#undef GC_SAVE_CONTEXT_FOR_CONSERVATIVE_SCANNING
+#endif
 
 // method dispatch profiling --------------------------------------------------
 

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -362,6 +362,7 @@ JL_NO_ASAN static void segv_handler(int sig, siginfo_t *info, void *context)
         return;
     }
     if (sig == SIGSEGV && info->si_code == SEGV_ACCERR && jl_addr_is_safepoint((uintptr_t)info->si_addr) && !is_write_fault(context)) {
+        jl_save_context_for_conservative_scanning(ct->ptls, context);
         jl_set_gc_and_wait();
         // Do not raise sigint on worker thread
         if (jl_atomic_load_relaxed(&ct->tid) != 0)


### PR DESCRIPTION
Cherry-picking changes from https://github.com/JuliaLang/julia/pull/55003 to enable saving registers of tasks that were active right before GC.

NB: Some changes need to be propagated to https://github.com/mmtk/mmtk-julia to reflect the changes in `jl_tls_states_t`: see https://github.com/mmtk/mmtk-julia/pull/159.