### PR TITLE
Pin pointer literals in code, and julia values in julia_to_scm

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -722,6 +722,7 @@ static value_t julia_to_list2_noalloc(fl_context_t *fl_ctx, jl_value_t *a, jl_va
 
 static value_t julia_to_scm_(fl_context_t *fl_ctx, jl_value_t *v, int check_valid)
 {
+    PTR_PIN(v);
     value_t retval;
     if (julia_to_scm_noalloc1(fl_ctx, v, &retval))
         return retval;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -471,6 +471,7 @@ static Value *literal_pointer_val(jl_codectx_t &ctx, jl_value_t *p)
 {
     if (p == NULL)
         return Constant::getNullValue(ctx.types().T_pjlvalue);
+    PTR_PIN(p);
     if (!ctx.emission_context.imaging)
         return literal_static_pointer_val(p, ctx.types().T_pjlvalue);
     Value *pgv = literal_pointer_val_slot(ctx, p);
@@ -486,6 +487,7 @@ static Value *literal_pointer_val(jl_codectx_t &ctx, jl_binding_t *p)
     // emit a pointer to any jl_value_t which will be valid across reloading code
     if (p == NULL)
         return Constant::getNullValue(ctx.types().T_pjlvalue);
+    PTR_PIN(p);
     if (!ctx.emission_context.imaging)
         return literal_static_pointer_val(p, ctx.types().T_pjlvalue);
     // bindings are prefixed with jl_bnd#

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -471,9 +471,10 @@ static Value *literal_pointer_val(jl_codectx_t &ctx, jl_value_t *p)
 {
     if (p == NULL)
         return Constant::getNullValue(ctx.types().T_pjlvalue);
-    PTR_PIN(p);
     if (!ctx.emission_context.imaging)
+        // literal_static_pointer_val will pin p.
         return literal_static_pointer_val(p, ctx.types().T_pjlvalue);
+    PTR_PIN(p);
     Value *pgv = literal_pointer_val_slot(ctx, p);
     jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_const);
     return ai.decorateInst(maybe_mark_load_dereferenceable(
@@ -487,9 +488,10 @@ static Value *literal_pointer_val(jl_codectx_t &ctx, jl_binding_t *p)
     // emit a pointer to any jl_value_t which will be valid across reloading code
     if (p == NULL)
         return Constant::getNullValue(ctx.types().T_pjlvalue);
-    PTR_PIN(p);
     if (!ctx.emission_context.imaging)
+        // literal_static_pointer_val will pin p.
         return literal_static_pointer_val(p, ctx.types().T_pjlvalue);
+    PTR_PIN(p);
     // bindings are prefixed with jl_bnd#
     Value *pgv = julia_pgv(ctx, "jl_bnd#", p->name, p->owner, p);
     jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_const);

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -242,7 +242,7 @@ void add_named_global(StringRef name, void *addr);
 
 static inline Constant *literal_static_pointer_val(const void *p, Type *T)
 {
-    PTR_PIN(p);
+    PTR_PIN((void*)p);
     // this function will emit a static pointer into the generated code
     // the generated code will only be valid during the current session,
     // and thus, this should typically be avoided in new API's

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -242,6 +242,7 @@ void add_named_global(StringRef name, void *addr);
 
 static inline Constant *literal_static_pointer_val(const void *p, Type *T)
 {
+    PTR_PIN(p);
     // this function will emit a static pointer into the generated code
     // the generated code will only be valid during the current session,
     // and thus, this should typically be avoided in new API's


### PR DESCRIPTION
Julia may embed heap pointers in the code. Those objects cannot be moved, otherwise the pointer value in the code becomes invalid. This PR pins those pointers in `literal_pointer_val` and `literal_static_pointer_val`.

Julia also reference heap pointers from scm/flisp values. We pin those heap pointers in `julia_to_scm_`.