### PR TITLE
Removing `WITH_MMTK`

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -80,9 +80,6 @@ HAVE_SSP := 0
 WITH_GC_VERIFY := 0
 WITH_GC_DEBUG_ENV := 0
 
-# Use MMTk GC
-WITH_MMTK ?= 0
-
 # Enable DTrace support
 WITH_DTRACE := 0
 
@@ -832,7 +829,7 @@ JCXXFLAGS += -DGC_DEBUG_ENV
 JCFLAGS += -DGC_DEBUG_ENV
 endif
 
-ifeq ($(WITH_MMTK), 1)
+ifneq ($(MMTK_PLAN), )
 ifeq (${MMTK_JULIA_DIR},)
 $(error MMTK_JULIA_DIR must be set to use MMTk)
 endif
@@ -848,10 +845,11 @@ endif
 ifeq (${MMTK_PLAN},Immix)
 JCXXFLAGS += -DMMTK_PLAN_IMMIX
 JCFLAGS += -DMMTK_PLAN_IMMIX
-endif
-ifeq (${MMTK_PLAN},StickyImmix)
+else ifeq (${MMTK_PLAN},StickyImmix)
 JCXXFLAGS += -DMMTK_PLAN_STICKYIMMIX
 JCFLAGS += -DMMTK_PLAN_STICKYIMMIX
+else
+$(error "Unsupported MMTk plan: $(MMTK_PLAN)")
 endif
 MMTK_DIR = ${MMTK_JULIA_DIR}/mmtk
 MMTK_API_INC = $(MMTK_DIR)/api
@@ -1863,7 +1861,7 @@ PRINT_PERL = printf '    %b %b\n' $(PERLCOLOR)PERL$(ENDCOLOR) $(BINCOLOR)$(GOAL)
 PRINT_FLISP = printf '    %b %b\n' $(FLISPCOLOR)FLISP$(ENDCOLOR) $(BINCOLOR)$(GOAL)$(ENDCOLOR); $(1)
 PRINT_JULIA = printf '    %b %b\n' $(JULIACOLOR)JULIA$(ENDCOLOR) $(BINCOLOR)$(GOAL)$(ENDCOLOR); $(1)
 PRINT_DTRACE = printf '    %b %b\n' $(DTRACECOLOR)DTRACE$(ENDCOLOR) $(BINCOLOR)$(GOAL)$(ENDCOLOR); $(1)
-ifeq ($(WITH_MMTK), 1)
+ifneq ($(MMTK_PLAN), )
 PRINT_MMTK = printf '    %b %b\n' $(LINKCOLOR)MMTK$(ENDCOLOR) $(BINCOLOR)$(GOAL)$(ENDCOLOR); $(1)
 endif
 
@@ -1876,7 +1874,7 @@ PRINT_PERL = echo '$(subst ','\'',$(1))'; $(1)
 PRINT_FLISP = echo '$(subst ','\'',$(1))'; $(1)
 PRINT_JULIA = echo '$(subst ','\'',$(1))'; $(1)
 PRINT_DTRACE = echo '$(subst ','\'',$(1))'; $(1)
-ifeq ($(WITH_MMTK), 1)
+ifneq ($(MMTK_PLAN), )
 PRINT_MMTK = echo '$(subst ','\'',$(1))'; $(1)
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -42,7 +42,7 @@ endif
 
 # GC source code. It depends on which GC implementation to use.
 GC_SRCS := gc-common gc-stacks gc-alloc-profiler gc-heap-snapshot
-ifeq ($(WITH_MMTK), 1)
+ifneq ($(MMTK_PLAN), )
 GC_SRCS += gc-mmtk
 else
 GC_SRCS += gc-stock gc-debug gc-pages gc-page-profiler
@@ -63,7 +63,7 @@ CG_LLVMLINK :=
 ifeq ($(JULIACODEGEN),LLVM)
 # Currently these files are used by both GCs. But we should make the list specific to stock, and MMTk should have its own implementation.
 GC_CODEGEN_SRCS := llvm-final-gc-lowering llvm-late-gc-lowering llvm-gc-invariant-verifier
-ifeq ($(WITH_MMTK), 1)
+ifneq ($(MMTK_PLAN), )
 FLAGS += -I$(MMTK_API_INC)
 GC_CODEGEN_SRCS += llvm-late-gc-lowering-mmtk
 else
@@ -122,7 +122,7 @@ UV_HEADERS += uv.h
 UV_HEADERS += uv/*.h
 endif
 PUBLIC_HEADERS := $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(addprefix $(SRCDIR)/,work-stealing-queue.h gc-interface.h gc-tls-common.h julia.h julia_assert.h julia_threads.h julia_fasttls.h julia_locks.h julia_atomics.h jloptions.h)
-ifeq ($(WITH_MMTK), 1)
+ifneq ($(MMTK_PLAN), )
 	PUBLIC_HEADERS += $(addprefix $(SRCDIR)/,gc-tls-mmtk.h)
 else
 	PUBLIC_HEADERS += $(addprefix $(SRCDIR)/,gc-tls-stock.h)
@@ -250,7 +250,7 @@ $(BUILDDIR)/%.h.gen : $(SRCDIR)/%.d
 	mv $@.tmp $@
 
 # Compile files from the binding side and copy so file into lib folder
-ifeq ($(WITH_MMTK), 1)
+ifneq ($(MMTK_PLAN), )
 $(MMTK_LIB_DST): $(MMTK_LIB_SRC)
 	@$(call PRINT_MMTK, cp $< $@)
 endif


### PR DESCRIPTION
Removing `WITH_MMTK` and deciding whether to build with MMTk based on `MMTK_PLAN`.