### PR TITLE
Pin pointer literals in code, and julia values in julia_to_scm

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -815,6 +815,7 @@ static value_t julia_to_list2_noalloc(fl_context_t *fl_ctx, jl_value_t *a, jl_va
 
 static value_t julia_to_scm_(fl_context_t *fl_ctx, jl_value_t *v, int check_valid)
 {
+    PTR_PIN(v);
     value_t retval;
     if (julia_to_scm_noalloc1(fl_ctx, v, &retval))
         return retval;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -578,6 +578,7 @@ static Value *literal_pointer_val(jl_codectx_t &ctx, jl_value_t *p)
 {
     if (p == NULL)
         return Constant::getNullValue(ctx.types().T_pjlvalue);
+    PTR_PIN(p);
     Value *pgv = literal_pointer_val_slot(ctx, p);
     jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_const);
     auto load = ai.decorateInst(maybe_mark_load_dereferenceable(

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -308,6 +308,7 @@ void add_named_global(StringRef name, void *addr) JL_NOTSAFEPOINT;
 
 static inline Constant *literal_static_pointer_val(const void *p, Type *T) JL_NOTSAFEPOINT
 {
+    PTR_PIN((void*)p);
     // this function will emit a static pointer into the generated code
     // the generated code will only be valid during the current session,
     // and thus, this should typically be avoided in new API's

--- a/src/julia.h
+++ b/src/julia.h
@@ -2755,6 +2755,8 @@ extern void mmtk_object_reference_write_slow(void* mutator, const void* parent, 
 #define MMTK_IMMORTAL_BUMP_ALLOCATOR (0)
 
 // VO bit is required to support conservative stack scanning and moving.
+// NB: We have to set VO bit even if this is a non_moving build. Otherwise, assertions in mmtk-core
+// will complain about seeing objects without VO bit.
 #define MMTK_NEEDS_VO_BIT (1)
 
 void mmtk_immortal_post_alloc_fast(MMTkMutatorContext* mutator, void* obj, size_t size);


### PR DESCRIPTION
Backporting https://github.com/mmtk/julia/pull/63 to `dev`. 