### PR TITLE
Record hidden ptr in layout

### DIFF
--- a/base/runtime_internals.jl
+++ b/base/runtime_internals.jl
@@ -521,7 +521,9 @@ struct DataTypeLayout
     size::UInt32
     nfields::UInt32
     npointers::UInt32
+    nhidden_pointers::UInt32
     firstptr::Int32
+    firsthiddenptr::Int32
     alignment::UInt16
     flags::UInt16
     # haspadding : 1;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3007,21 +3007,21 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_typename_type->name->mt = jl_nonfunction_mt;
     jl_typename_type->super = jl_any_type;
     jl_typename_type->parameters = jl_emptysvec;
-    jl_typename_type->name->n_uninitialized = 16 - 2;
-    jl_typename_type->name->names = jl_perm_symsvec(16, "name", "module",
-                                                    "names", "atomicfields", "constfields",
+    jl_typename_type->name->n_uninitialized = 17 - 2;
+    jl_typename_type->name->names = jl_perm_symsvec(17, "name", "module",
+                                                    "names", "atomicfields", "constfields", "hiddenptrfields",
                                                     "wrapper", "Typeofwrapper", "cache", "linearcache",
                                                     "mt", "partial",
                                                     "hash", "n_uninitialized",
                                                     "flags", // "abstract", "mutable", "mayinlinealloc",
                                                     "max_methods", "constprop_heuristic");
-    const static uint32_t typename_constfields[1] = { 0x00003a27 }; // (1<<0)|(1<<1)|(1<<2)|(1<<5)|(1<<9)|(1<<11)|(1<<12)|(1<<13) ; TODO: put back (1<<3)|(1<<4) in this list
-    const static uint32_t typename_atomicfields[1] = { 0x00000180 }; // (1<<7)|(1<<8)
+    const static uint32_t typename_constfields[1] = { 0x0000744f }; // (1<<0)|(1<<1)|(1<<2)|(1<<6)|(1<<10)|(1<<12)|(1<<13)|(1<<14) ; TODO: put back (1<<3)|(1<<4)|(1<<5) in this list
+    const static uint32_t typename_atomicfields[1] = { 0x00000300 }; // (1<<8)|(1<<9)
     jl_typename_type->name->constfields = typename_constfields;
     jl_typename_type->name->atomicfields = typename_atomicfields;
     jl_precompute_memoized_dt(jl_typename_type, 1);
-    jl_typename_type->types = jl_svec(16, jl_symbol_type, jl_any_type /*jl_module_type*/,
-                                      jl_simplevector_type, jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/,
+    jl_typename_type->types = jl_svec(17, jl_symbol_type, jl_any_type /*jl_module_type*/,
+                                      jl_simplevector_type, jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/,
                                       jl_type_type, jl_type_type, jl_simplevector_type, jl_simplevector_type,
                                       jl_methtable_type, jl_any_type,
                                       jl_any_type /*jl_long_type*/, jl_any_type /*jl_int32_type*/,
@@ -3338,11 +3338,12 @@ void jl_init_types(void) JL_GC_DISABLED
     memory_datatype->ismutationfree = 0;
 
     jl_datatype_t *jl_memoryref_supertype = (jl_datatype_t*)jl_apply_type1((jl_value_t*)jl_ref_type, jl_svecref(tv, 1));
+    const static uint32_t memoryref_hiddenptrfields[1] = { 0x00000001 }; // (1<<0) - field 0 is a hidden pointer
     jl_datatype_t *memoryref_datatype =
-        jl_new_datatype(jl_symbol("GenericMemoryRef"), core, jl_memoryref_supertype, tv,
+        jl_new_datatype_with_hiddenptrs(jl_symbol("GenericMemoryRef"), core, jl_memoryref_supertype, tv,
                         jl_perm_symsvec(2, "ptr_or_offset", "mem"),
                         jl_svec(2, pointer_void, memory_datatype),
-                        jl_emptysvec, 0, 0, 2);
+                        jl_emptysvec, 0, 0, 2, memoryref_hiddenptrfields);
     jl_genericmemoryref_typename = memoryref_datatype->name;
     jl_genericmemoryref_type = (jl_unionall_t*)jl_genericmemoryref_typename->wrapper;
     memoryref_datatype->ismutationfree = 0;
@@ -3849,13 +3850,14 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_typename_type->types, 1, jl_module_type);
     jl_svecset(jl_typename_type->types, 3, jl_voidpointer_type);
     jl_svecset(jl_typename_type->types, 4, jl_voidpointer_type);
-    jl_svecset(jl_typename_type->types, 5, jl_type_type);
+    jl_svecset(jl_typename_type->types, 5, jl_voidpointer_type); // hiddenptrfields
     jl_svecset(jl_typename_type->types, 6, jl_type_type);
-    jl_svecset(jl_typename_type->types, 11, jl_long_type);
-    jl_svecset(jl_typename_type->types, 12, jl_int32_type);
-    jl_svecset(jl_typename_type->types, 13, jl_uint8_type);
+    jl_svecset(jl_typename_type->types, 7, jl_type_type);
+    jl_svecset(jl_typename_type->types, 12, jl_long_type);
+    jl_svecset(jl_typename_type->types, 13, jl_int32_type);
     jl_svecset(jl_typename_type->types, 14, jl_uint8_type);
     jl_svecset(jl_typename_type->types, 15, jl_uint8_type);
+    jl_svecset(jl_typename_type->types, 16, jl_uint8_type);
     jl_svecset(jl_methtable_type->types, 4, jl_long_type);
     jl_svecset(jl_methtable_type->types, 5, jl_module_type);
     jl_svecset(jl_methtable_type->types, 6, jl_array_any_type);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3009,25 +3009,27 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_typename_type->parameters = jl_emptysvec;
     jl_typename_type->name->n_uninitialized = 17 - 2;
     jl_typename_type->name->names = jl_perm_symsvec(17, "name", "module",
-                                                    "names", "atomicfields", "constfields", "hiddenptrfields",
+                                                    "names", "atomicfields", "constfields",
                                                     "wrapper", "Typeofwrapper", "cache", "linearcache",
                                                     "mt", "partial",
                                                     "hash", "n_uninitialized",
                                                     "flags", // "abstract", "mutable", "mayinlinealloc",
-                                                    "max_methods", "constprop_heuristic");
-    const static uint32_t typename_constfields[1] = { 0x0000744f }; // (1<<0)|(1<<1)|(1<<2)|(1<<6)|(1<<10)|(1<<12)|(1<<13)|(1<<14) ; TODO: put back (1<<3)|(1<<4)|(1<<5) in this list
-    const static uint32_t typename_atomicfields[1] = { 0x00000300 }; // (1<<8)|(1<<9)
+                                                    "max_methods", "constprop_heuristic",
+                                                    "hiddenptrfields");
+    const static uint32_t typename_constfields[1] = { 0x00003a27 }; // (1<<0)|(1<<1)|(1<<2)|(1<<5)|(1<<9)|(1<<11)|(1<<12)|(1<<13) ; TODO: put back (1<<3)|(1<<4) in this list
+    const static uint32_t typename_atomicfields[1] = { 0x00000180 }; // (1<<7)|(1<<8)
     jl_typename_type->name->constfields = typename_constfields;
     jl_typename_type->name->atomicfields = typename_atomicfields;
     jl_precompute_memoized_dt(jl_typename_type, 1);
     jl_typename_type->types = jl_svec(17, jl_symbol_type, jl_any_type /*jl_module_type*/,
-                                      jl_simplevector_type, jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/,
+                                      jl_simplevector_type, jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/,
                                       jl_type_type, jl_type_type, jl_simplevector_type, jl_simplevector_type,
                                       jl_methtable_type, jl_any_type,
                                       jl_any_type /*jl_long_type*/, jl_any_type /*jl_int32_type*/,
                                       jl_any_type /*jl_uint8_type*/,
                                       jl_any_type /*jl_uint8_type*/,
-                                      jl_any_type /*jl_uint8_type*/);
+                                      jl_any_type /*jl_uint8_type*/,
+                                      jl_any_type/*jl_voidpointer_type*/);
 
     jl_methtable_type->name = jl_new_typename_in(jl_symbol("MethodTable"), core, 0, 1);
     jl_methtable_type->name->wrapper = (jl_value_t*)jl_methtable_type;
@@ -3850,14 +3852,14 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_typename_type->types, 1, jl_module_type);
     jl_svecset(jl_typename_type->types, 3, jl_voidpointer_type);
     jl_svecset(jl_typename_type->types, 4, jl_voidpointer_type);
-    jl_svecset(jl_typename_type->types, 5, jl_voidpointer_type); // hiddenptrfields
+    jl_svecset(jl_typename_type->types, 5, jl_type_type);
     jl_svecset(jl_typename_type->types, 6, jl_type_type);
-    jl_svecset(jl_typename_type->types, 7, jl_type_type);
-    jl_svecset(jl_typename_type->types, 12, jl_long_type);
-    jl_svecset(jl_typename_type->types, 13, jl_int32_type);
+    jl_svecset(jl_typename_type->types, 11, jl_long_type);
+    jl_svecset(jl_typename_type->types, 12, jl_int32_type);
+    jl_svecset(jl_typename_type->types, 13, jl_uint8_type);
     jl_svecset(jl_typename_type->types, 14, jl_uint8_type);
     jl_svecset(jl_typename_type->types, 15, jl_uint8_type);
-    jl_svecset(jl_typename_type->types, 16, jl_uint8_type);
+    jl_svecset(jl_typename_type->types, 16, jl_voidpointer_type); // hiddenptrfields
     jl_svecset(jl_methtable_type->types, 4, jl_long_type);
     jl_svecset(jl_methtable_type->types, 5, jl_module_type);
     jl_svecset(jl_methtable_type->types, 6, jl_array_any_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -532,7 +532,6 @@ typedef struct {
     jl_svec_t *names;  // field names
     const uint32_t *atomicfields; // if any fields are atomic, we record them here
     const uint32_t *constfields; // if any fields are const, we record them here
-    const uint32_t *hiddenptrfields; // if any fields are hidden pointers, we record them here
     // `wrapper` is either the only instantiation of the type (if no parameters)
     // or a UnionAll accepting parameters to make an instantiation.
     jl_value_t *wrapper;
@@ -550,6 +549,7 @@ typedef struct {
     uint8_t _reserved:5;
     uint8_t max_methods; // override for inference's max_methods setting (0 = no additional limit or relaxation)
     uint8_t constprop_heustic; // override for inference's constprop heuristic
+    const uint32_t *hiddenptrfields; // if any fields are hidden pointers, we record them here
 } jl_typename_t;
 
 typedef struct {

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1949,6 +1949,8 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                     size_t fldsize = sizeof(jl_datatype_layout_t) + nf * fieldsize;
                     if (!is_foreign_type && dt->layout->first_ptr != -1)
                         fldsize += np << dt->layout->flags.fielddesc_type;
+                    if (!is_foreign_type && dt->layout->first_hidden_ptr != -1)
+                        fldsize += dt->layout->nhidden_pointers * jl_hidden_desc_size(dt->layout->flags.fielddesc_type);
                     uintptr_t layout = LLT_ALIGN(ios_pos(s->const_data), sizeof(void*));
                     write_padding(s->const_data, layout - ios_pos(s->const_data)); // realign stream
                     newdt->layout = NULL; // relocation offset

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1950,7 +1950,7 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                     if (!is_foreign_type && dt->layout->first_ptr != -1)
                         fldsize += np << dt->layout->flags.fielddesc_type;
                     if (!is_foreign_type && dt->layout->first_hidden_ptr != -1)
-                        fldsize += dt->layout->nhidden_pointers * jl_hidden_desc_size(dt->layout->flags.fielddesc_type);
+                        fldsize += dt->layout->nhidden_pointers << dt->layout->flags.fielddesc_type;
                     uintptr_t layout = LLT_ALIGN(ios_pos(s->const_data), sizeof(void*));
                     write_padding(s->const_data, layout - ios_pos(s->const_data)); // realign stream
                     newdt->layout = NULL; // relocation offset


### PR DESCRIPTION
This PR records the hidden pointer offsets in `jl_datatype_layout_t`. Hidden pointers are fields like `ptr_or_offset` in `jl_genericmemoryref_t`, which is not recorded as a pointer but actually may be heap (internal) pointers.

There might be other types of hidden pointers. Currently we assume the recorded hidden pointers are all like `ptr_or_offset` -- a union of an internal pointer, or an integer.

The current implementation adds `hiddenptrfields` to `jl_typename_t`, and specifically define `hiddenptrfields` for `jl_genericmemoryref_t`. This is not an ideal solution. I think a better solution would be to introduce a new type that represents a hidden pointer, and use the type for fields like `ptr_or_offset`. However, I am not familiar with Julia's type system, and didn't get it to work. The current approach using `hiddenptrfields` is a workaround.