### PR TITLE
make preserve/unpreserve_handle use the pin/unpin_count functions

### DIFF
--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -60,24 +60,32 @@ iolock_end() = ccall(:jl_iolock_end, Cvoid, ())
 const uvhandles = IdDict()
 const preserve_handle_lock = Threads.SpinLock()
 @nospecializeinfer function preserve_handle(@nospecialize(x))
-    lock(preserve_handle_lock)
-    v = get(uvhandles, x, 0)::Int
-    uvhandles[x] = v + 1
-    unlock(preserve_handle_lock)
+    @static if Base.USING_STOCK_GC
+        lock(preserve_handle_lock)
+        v = get(uvhandles, x, 0)::Int
+        uvhandles[x] = v + 1
+        unlock(preserve_handle_lock)
+    else
+        Base.increment_tpin_count!(x)
+    end
     nothing
 end
 @nospecializeinfer function unpreserve_handle(@nospecialize(x))
-    lock(preserve_handle_lock)
-    v = get(uvhandles, x, 0)::Int
-    if v == 0
+    @static if Base.USING_STOCK_GC
+        lock(preserve_handle_lock)
+        v = get(uvhandles, x, 0)::Int
+        if v == 0
+            unlock(preserve_handle_lock)
+            error("unbalanced call to unpreserve_handle for $(typeof(x))")
+        elseif v == 1
+            pop!(uvhandles, x)
+        else
+            uvhandles[x] = v - 1
+        end
         unlock(preserve_handle_lock)
-        error("unbalanced call to unpreserve_handle for $(typeof(x))")
-    elseif v == 1
-        pop!(uvhandles, x)
     else
-        uvhandles[x] = v - 1
+        Base.decrement_tpin_count!(x)
     end
-    unlock(preserve_handle_lock)
     nothing
 end
 


### PR DESCRIPTION
See PR's title.

@qinsoon, @udesou: this refactor fixes the `LibCURL.jl` tests.

```julia
              _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.13.0-DEV.356 (2025-08-21)
 _/ |\__'_|_|_|\__'_|  |  dcn-refactor-preserve-and-unpreserve_handle/a29d4f466d (fork: 46 commits, 147 days)
|__/                   |

julia> Base.runtests(["LibCURL"])
Running parallel tests with:
  getpid() = 39153
  nworkers() = 1
  nthreads(:interactive) = 1
  nthreads(:default) = 1
  Sys.CPU_THREADS = 8
  Sys.total_memory() = 15.399 GiB
  Sys.free_memory() = 9.352 GiB
  Sys.uptime() = 4455.67 (1.2 hours)

Test  (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
LibCURL    (1) |        started at 2025-08-21T15:19:24.775
LibCURL    (1) |     1.16 |   0.00 |  0.0 |      22.97 |   488.36

Test Summary: | Pass  Total  Time
  Overall     |    6      6  4.6s
    SUCCESS


```