### PR TITLE
Fix warnings in gc-mmtk.c

### DIFF
--- a/src/gc-mmtk.c
+++ b/src/gc-mmtk.c
@@ -900,7 +900,7 @@ JL_DLLEXPORT void jl_gc_scan_julia_exc_obj(void* obj_raw, void* closure, Process
                 // GC-managed values inside.
                 size_t njlvals = jl_bt_num_jlvals(bt_entry);
                 while (jlval_index < njlvals) {
-                    jl_value_t** new_obj_slot = &bt_entry[2 + jlval_index].jlvalue;
+                    jl_value_t** new_obj_slot = (jl_value_t**)&bt_entry[2 + jlval_index].jlvalue;
                     jlval_index += 1;
                     process_slot(closure, new_obj_slot);
                 }
@@ -908,7 +908,7 @@ JL_DLLEXPORT void jl_gc_scan_julia_exc_obj(void* obj_raw, void* closure, Process
             }
 
             jl_bt_element_t *stack_raw = (jl_bt_element_t *)(excstack+1);
-            jl_value_t** stack_obj_slot = &stack_raw[itr-1].jlvalue;
+            jl_value_t** stack_obj_slot = (jl_value_t**)&stack_raw[itr-1].jlvalue;
 
             itr = jl_excstack_next(excstack, itr);
             bt_index = 0;


### PR DESCRIPTION
Fix the following warnings:
```
/home/yilin/Code/julia_workspace/julia/src/gc-mmtk.c: In function 'jl_gc_scan_julia_exc_obj':
/home/yilin/Code/julia_workspace/julia/src/gc-mmtk.c:903:49: warning: initialization of 'jl_value_t **' {aka 'struct _jl_value_t **'} from incompatible pointer type 'union <anonymous> *' [-Wincompatible-pointer-types]
  903 |                     jl_value_t** new_obj_slot = &bt_entry[2 + jlval_index].jlvalue;
      |                                                 ^
/home/yilin/Code/julia_workspace/julia/src/gc-mmtk.c:911:43: warning: initialization of 'jl_value_t **' {aka 'struct _jl_value_t **'} from incompatible pointer type 'union <anonymous> *' [-Wincompatible-pointer-types]
  911 |             jl_value_t** stack_obj_slot = &stack_raw[itr-1].jlvalue;
      | 
```